### PR TITLE
확장에 용이한 세션 로그인 구조 개발

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,6 +32,14 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-validation</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.session</groupId>
+            <artifactId>spring-session-data-redis</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>com.h2database</groupId>

--- a/src/main/java/com/campool/CampoolApplication.java
+++ b/src/main/java/com/campool/CampoolApplication.java
@@ -2,7 +2,9 @@ package com.campool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableRedisHttpSession
 @SpringBootApplication
 public class CampoolApplication {
 

--- a/src/main/java/com/campool/service/SessionAuthService.java
+++ b/src/main/java/com/campool/service/SessionAuthService.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class SessionAuthService implements AuthService {
 
-    public static final String AUTH_USER_KEY = "userSignUp";
+    public static final String AUTH_USER_KEY = "userId";
 
     @NonNull
     private final UserService userService;
@@ -23,7 +23,7 @@ public class SessionAuthService implements AuthService {
     public void authenticate(UserLoginRequest userLoginRequest) {
         UserSignUp userSignUp = userService
                 .getByIdAndPw(userLoginRequest.getId(), userLoginRequest.getPassword());
-        session.setAttribute(AUTH_USER_KEY, userSignUp);
+        session.setAttribute(AUTH_USER_KEY, userSignUp.getId());
     }
 
     @Override


### PR DESCRIPTION
## 작업 내용
- 확장에 용이한 구조를 위해 Session Storage를 local이 아닌 Global환경으로 분리 
- Session Storage 구현체로 Redis 사용
- 세션 로그인 시 사용자 전체 정보가 아닌 id만 저장하도록 변경

## 주의 사항
spring-boot-starter-data-redis 를 사용하여 spring session, redis 사용 시 필요한 구현체들을 자동으로 주입받았습니다.

>  참조이슈
> #10  
