### PR TITLE
MySQL Replication 구조 적용

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,14 @@
             <artifactId>springfox-boot-starter</artifactId>
             <version>3.0.0</version>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.projectlombok</groupId>

--- a/src/main/java/com/campool/CampoolApplication.java
+++ b/src/main/java/com/campool/CampoolApplication.java
@@ -2,8 +2,10 @@ package com.campool;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 
+@EnableCaching
 @EnableRedisHttpSession
 @SpringBootApplication
 public class CampoolApplication {

--- a/src/main/java/com/campool/configuration/DataSourceConfiguration.java
+++ b/src/main/java/com/campool/configuration/DataSourceConfiguration.java
@@ -18,6 +18,9 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 @Configuration
 public class DataSourceConfiguration {
 
+    public static String MASTER = "master";
+    public static String SLAVE = "slave";
+
     @ConfigurationProperties(prefix = "campool.datasource.master")
     @Bean
     public DataSource masterDataSource() {
@@ -34,8 +37,8 @@ public class DataSourceConfiguration {
     public DataSource routingDataSource(@Qualifier("masterDataSource") DataSource masterDataSource,
             @Qualifier("slaveDataSource") DataSource slaveDataSource) {
         Map<Object, Object> targetDataSources = new HashMap<>();
-        targetDataSources.put("master", masterDataSource);
-        targetDataSources.put("slave", slaveDataSource);
+        targetDataSources.put(MASTER, masterDataSource);
+        targetDataSources.put(SLAVE, slaveDataSource);
 
         RoutingDataSource routingDataSource = new RoutingDataSource();
         routingDataSource.setTargetDataSources(targetDataSources);

--- a/src/main/java/com/campool/configuration/DataSourceConfiguration.java
+++ b/src/main/java/com/campool/configuration/DataSourceConfiguration.java
@@ -1,5 +1,8 @@
 package com.campool.configuration;
 
+import static com.campool.enumeration.DataSourceType.MASTER;
+import static com.campool.enumeration.DataSourceType.SLAVE;
+
 import com.campool.configuration.datasource.RoutingDataSource;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,9 +20,6 @@ import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
 @EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
 @Configuration
 public class DataSourceConfiguration {
-
-    public static String MASTER = "master";
-    public static String SLAVE = "slave";
 
     @ConfigurationProperties(prefix = "campool.datasource.master")
     @Bean

--- a/src/main/java/com/campool/configuration/DataSourceConfiguration.java
+++ b/src/main/java/com/campool/configuration/DataSourceConfiguration.java
@@ -1,0 +1,52 @@
+package com.campool.configuration;
+
+import com.campool.configuration.datasource.RoutingDataSource;
+import java.util.HashMap;
+import java.util.Map;
+import javax.sql.DataSource;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+@EnableAutoConfiguration(exclude = {DataSourceAutoConfiguration.class})
+@Configuration
+public class DataSourceConfiguration {
+
+    @ConfigurationProperties(prefix = "campool.datasource.master")
+    @Bean
+    public DataSource masterDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @ConfigurationProperties(prefix = "campool.datasource.slave")
+    @Bean
+    public DataSource slaveDataSource() {
+        return DataSourceBuilder.create().build();
+    }
+
+    @Bean
+    public DataSource routingDataSource(@Qualifier("masterDataSource") DataSource masterDataSource,
+            @Qualifier("slaveDataSource") DataSource slaveDataSource) {
+        Map<Object, Object> targetDataSources = new HashMap<>();
+        targetDataSources.put("master", masterDataSource);
+        targetDataSources.put("slave", slaveDataSource);
+
+        RoutingDataSource routingDataSource = new RoutingDataSource();
+        routingDataSource.setTargetDataSources(targetDataSources);
+        routingDataSource.setDefaultTargetDataSource(masterDataSource);
+        return routingDataSource;
+    }
+
+    @Primary
+    @Bean
+    public DataSource dataSource(DataSource routingDataSource) {
+        return new LazyConnectionDataSourceProxy(routingDataSource);
+    }
+
+}

--- a/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
+++ b/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
@@ -1,5 +1,8 @@
 package com.campool.configuration.datasource;
 
+import static com.campool.configuration.DataSourceConfiguration.MASTER;
+import static com.campool.configuration.DataSourceConfiguration.SLAVE;
+
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
@@ -8,6 +11,6 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
     @Override
     protected Object determineCurrentLookupKey() {
         return TransactionSynchronizationManager.isCurrentTransactionReadOnly() ?
-                "slave" : "master";
+                SLAVE : MASTER;
     }
 }

--- a/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
+++ b/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
@@ -1,7 +1,7 @@
 package com.campool.configuration.datasource;
 
-import static com.campool.configuration.DataSourceConfiguration.MASTER;
-import static com.campool.configuration.DataSourceConfiguration.SLAVE;
+import static com.campool.enumeration.DataSourceType.MASTER;
+import static com.campool.enumeration.DataSourceType.SLAVE;
 
 import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
 import org.springframework.transaction.support.TransactionSynchronizationManager;

--- a/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
+++ b/src/main/java/com/campool/configuration/datasource/RoutingDataSource.java
@@ -1,0 +1,13 @@
+package com.campool.configuration.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        return TransactionSynchronizationManager.isCurrentTransactionReadOnly() ?
+                "slave" : "master";
+    }
+}

--- a/src/main/java/com/campool/enumeration/DataSourceType.java
+++ b/src/main/java/com/campool/enumeration/DataSourceType.java
@@ -1,0 +1,6 @@
+package com.campool.enumeration;
+
+public enum DataSourceType {
+    MASTER,
+    SLAVE
+}

--- a/src/main/java/com/campool/service/GearTypeService.java
+++ b/src/main/java/com/campool/service/GearTypeService.java
@@ -5,6 +5,7 @@ import com.campool.model.GearType;
 import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,6 +15,7 @@ public class GearTypeService {
     @NonNull
     private final GearTypeMapper gearTypeMapper;
 
+    @Cacheable(value = "gearTypes")
     public List<GearType> getGearTypes() {
         return gearTypeMapper.selectGearTypes();
     }

--- a/src/main/java/com/campool/service/RentalService.java
+++ b/src/main/java/com/campool/service/RentalService.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class RentalService {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,4 +1,4 @@
-spring.cache.type=simple
+spring.cache.type=ehcache
 mybatis.mapper-locations=classpath*:/mapper/*.xml
 campool.datasource.master.jdbc-url=master-mysql-url
 campool.datasource.master.username=username

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.cache.type=simple
 mybatis.mapper-locations=classpath*:/mapper/*.xml
 campool.datasource.master.jdbc-url=master-mysql-url
 campool.datasource.master.username=username

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,7 @@
 mybatis.mapper-locations=classpath*:/mapper/*.xml
+campool.datasource.master.jdbc-url=master-mysql-url
+campool.datasource.master.username=username
+campool.datasource.master.password=password
+campool.datasource.slave.jdbc-url=slave-mysql-url
+campool.datasource.slave.username=username
+campool.datasource.slave.password=password

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ehcache xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:noNamespaceSchemaLocation="http://ehcache.org/ehcache.xsd"
+    maxBytesLocalHeap="50M" updateCheck="false">
+    <sizeOfPolicy maxDepth="1000"/>
+    <defaultCache eternal="false"
+        timeToIdleSeconds="0"
+        timeToLiveSeconds="3000"
+        overflowToDisk="false"
+        diskPersistent="false"
+        memoryStoreEvictionPolicy="LRU">
+    </defaultCache>
+    <cache name="gearTypes"
+        eternal="false"
+        timeToIdleSeconds="0"
+        timeToLiveSeconds="300"
+        overflowToDisk="false"
+        diskPersistent="false"
+        memoryStoreEvictionPolicy="LRU">
+    </cache>
+</ehcache>


### PR DESCRIPTION
## 작업 내용
- MySQL Master/Slave 구조로 변경하였습니다.
- Transactional readOnly 속성을 통해 DB 요청을 분기하도록 변경하였습니다.

## 주의 사항
렌트정보 요청 시 Slave 노드로 분기시켜 부하를 분산시킵니다.
데이터 실시간성이 필요한 유저 서비스는 적용하지 않았습니다.

>  참조이슈
> #19 
