### PR TITLE
캠핑용품 타입 데이터 관리 기능

### DIFF
--- a/src/main/java/com/campool/controller/GearTypeController.java
+++ b/src/main/java/com/campool/controller/GearTypeController.java
@@ -25,26 +25,26 @@ public class GearTypeController {
     private final GearTypeService gearTypeService;
 
     @LoginValidation
-    @GetMapping("/types")
+    @GetMapping("/gear-types")
     public List<GearType> getGearTypes() {
         return gearTypeService.getGearTypes();
     }
 
     @LoginValidation(role = Role.ADMIN)
-    @PostMapping("/types")
+    @PostMapping("/gear-types")
     public void registerGearType(@Valid GearTypeRegisterRequest gearTypeRegisterRequest) {
         gearTypeService.addGearType(gearTypeRegisterRequest.getName());
     }
 
     @LoginValidation(role = Role.ADMIN)
-    @PatchMapping("/types")
+    @PatchMapping("/gear-types")
     public void updateGearType(@Valid GearTypeUpdateRequest gearTypeUpdateRequest) {
         gearTypeService.updateByName(gearTypeUpdateRequest.getCurrentName(),
                 gearTypeUpdateRequest.getNewName());
     }
 
     @LoginValidation(role = Role.ADMIN)
-    @DeleteMapping("/types/{id}")
+    @DeleteMapping("/gear-types/{id}")
     public void deleteGearType(@PathVariable long id) {
         gearTypeService.deleteById(id);
     }

--- a/src/main/java/com/campool/controller/GearTypeController.java
+++ b/src/main/java/com/campool/controller/GearTypeController.java
@@ -45,7 +45,7 @@ public class GearTypeController {
 
     @LoginValidation(role = Role.ADMIN)
     @DeleteMapping("/types/{id}")
-    public void deleteGearType(@PathVariable int id) {
+    public void deleteGearType(@PathVariable long id) {
         gearTypeService.deleteById(id);
     }
 

--- a/src/main/java/com/campool/controller/GearTypeController.java
+++ b/src/main/java/com/campool/controller/GearTypeController.java
@@ -10,8 +10,10 @@ import java.util.List;
 import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -39,6 +41,12 @@ public class GearTypeController {
     public void updateGearType(@Valid GearTypeUpdateRequest gearTypeUpdateRequest) {
         gearTypeService.updateByName(gearTypeUpdateRequest.getCurrentName(),
                 gearTypeUpdateRequest.getNewName());
+    }
+
+    @LoginValidation(role = Role.ADMIN)
+    @DeleteMapping("/types/{id}")
+    public void deleteGearType(@PathVariable int id) {
+        gearTypeService.deleteById(id);
     }
 
 }

--- a/src/main/java/com/campool/controller/GearTypeController.java
+++ b/src/main/java/com/campool/controller/GearTypeController.java
@@ -1,12 +1,16 @@
 package com.campool.controller;
 
 import com.campool.annotation.LoginValidation;
+import com.campool.enumeration.Role;
 import com.campool.model.GearType;
+import com.campool.model.GearTypeRegisterRequest;
 import com.campool.service.GearTypeService;
 import java.util.List;
+import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RequiredArgsConstructor
@@ -20,6 +24,12 @@ public class GearTypeController {
     @GetMapping("/types")
     public List<GearType> getGearTypes() {
         return gearTypeService.getGearTypes();
+    }
+
+    @LoginValidation(role = Role.ADMIN)
+    @PostMapping("/types")
+    public void registerGearType(@Valid GearTypeRegisterRequest gearTypeRegisterRequest) {
+        gearTypeService.addGearType(gearTypeRegisterRequest.getName());
     }
 
 }

--- a/src/main/java/com/campool/controller/GearTypeController.java
+++ b/src/main/java/com/campool/controller/GearTypeController.java
@@ -4,12 +4,14 @@ import com.campool.annotation.LoginValidation;
 import com.campool.enumeration.Role;
 import com.campool.model.GearType;
 import com.campool.model.GearTypeRegisterRequest;
+import com.campool.model.GearTypeUpdateRequest;
 import com.campool.service.GearTypeService;
 import java.util.List;
 import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -30,6 +32,13 @@ public class GearTypeController {
     @PostMapping("/types")
     public void registerGearType(@Valid GearTypeRegisterRequest gearTypeRegisterRequest) {
         gearTypeService.addGearType(gearTypeRegisterRequest.getName());
+    }
+
+    @LoginValidation(role = Role.ADMIN)
+    @PatchMapping("/types")
+    public void updateGearType(@Valid GearTypeUpdateRequest gearTypeUpdateRequest) {
+        gearTypeService.updateByName(gearTypeUpdateRequest.getCurrentName(),
+                gearTypeUpdateRequest.getNewName());
     }
 
 }

--- a/src/main/java/com/campool/mapper/GearTypeMapper.java
+++ b/src/main/java/com/campool/mapper/GearTypeMapper.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.Update;
 
 @Mapper
 public interface GearTypeMapper {
@@ -20,5 +21,8 @@ public interface GearTypeMapper {
 
     @Insert("INSERT INTO TYPE(name) VALUES(#{name})")
     void insertGearType(String name);
+
+    @Update("UPDATE TYPE SET NAME = #{newName} WHERE NAME = #{currentName}")
+    void updateByName(String currentName, String newName);
 
 }

--- a/src/main/java/com/campool/mapper/GearTypeMapper.java
+++ b/src/main/java/com/campool/mapper/GearTypeMapper.java
@@ -21,7 +21,7 @@ public interface GearTypeMapper {
     GearType findGearTypeByName(String name);
 
     @Select("SELECT ID, NAME FROM TYPE WHERE ID = #{id}")
-    GearType findGearTypeById(int id);
+    GearType findGearTypeById(long id);
 
     @Insert("INSERT INTO TYPE(name) VALUES(#{name})")
     void insertGearType(String name);
@@ -30,6 +30,6 @@ public interface GearTypeMapper {
     void updateByName(String currentName, String newName);
 
     @Delete("DELETE FROM TYPE WHERE ID = #{id}")
-    void deleteById(int id);
+    void deleteById(long id);
 
 }

--- a/src/main/java/com/campool/mapper/GearTypeMapper.java
+++ b/src/main/java/com/campool/mapper/GearTypeMapper.java
@@ -2,6 +2,7 @@ package com.campool.mapper;
 
 import com.campool.model.GearType;
 import java.util.List;
+import org.apache.ibatis.annotations.Delete;
 import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
@@ -19,10 +20,16 @@ public interface GearTypeMapper {
     @Select("SELECT ID, NAME FROM TYPE WHERE NAME = #{name}")
     GearType findGearTypeByName(String name);
 
+    @Select("SELECT ID, NAME FROM TYPE WHERE ID = #{id}")
+    GearType findGearTypeById(int id);
+
     @Insert("INSERT INTO TYPE(name) VALUES(#{name})")
     void insertGearType(String name);
 
     @Update("UPDATE TYPE SET NAME = #{newName} WHERE NAME = #{currentName}")
     void updateByName(String currentName, String newName);
+
+    @Delete("DELETE FROM TYPE WHERE ID = #{id}")
+    void deleteById(int id);
 
 }

--- a/src/main/java/com/campool/mapper/GearTypeMapper.java
+++ b/src/main/java/com/campool/mapper/GearTypeMapper.java
@@ -2,6 +2,7 @@ package com.campool.mapper;
 
 import com.campool.model.GearType;
 import java.util.List;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Select;
 
@@ -13,5 +14,11 @@ public interface GearTypeMapper {
      */
     @Select("SELECT ID, NAME FROM TYPE")
     List<GearType> selectGearTypes();
+
+    @Select("SELECT ID, NAME FROM TYPE WHERE NAME = #{name}")
+    GearType findGearTypeByName(String name);
+
+    @Insert("INSERT INTO TYPE(name) VALUES(#{name})")
+    void insertGearType(String name);
 
 }

--- a/src/main/java/com/campool/model/GearTypeRegisterRequest.java
+++ b/src/main/java/com/campool/model/GearTypeRegisterRequest.java
@@ -1,0 +1,18 @@
+package com.campool.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@ToString
+public class GearTypeRegisterRequest {
+
+    @NotBlank(message = "캠핑용품 타입을 입력해주세요.")
+    @Size(max = 255, message = "최대 255자리까지 입력 가능합니다.")
+    private final String name;
+
+}

--- a/src/main/java/com/campool/model/GearTypeUpdateRequest.java
+++ b/src/main/java/com/campool/model/GearTypeUpdateRequest.java
@@ -1,0 +1,22 @@
+package com.campool.model;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+@Getter
+@RequiredArgsConstructor
+@ToString
+public class GearTypeUpdateRequest {
+
+    @NotBlank(message = "현재 타입 명이 필요합니다.")
+    @Size(max = 255, message = "최대 255자리까지 입력 가능합니다.")
+    private final String currentName;
+
+    @NotBlank(message = "새로운 타입 명을 입력해주세요.")
+    @Size(max = 255, message = "최대 255자리까지 입력 가능합니다.")
+    private final String newName;
+
+}

--- a/src/main/java/com/campool/service/GearTypeService.java
+++ b/src/main/java/com/campool/service/GearTypeService.java
@@ -40,7 +40,7 @@ public class GearTypeService {
         gearTypeMapper.updateByName(currentName, newName);
     }
 
-    public void deleteById(int id) {
+    public void deleteById(long id) {
         if (isNotValidGearType(gearTypeMapper.findGearTypeById(id))) {
             throw new NoSuchElementException("존재하지 않는 타입입니다.");
         }

--- a/src/main/java/com/campool/service/GearTypeService.java
+++ b/src/main/java/com/campool/service/GearTypeService.java
@@ -34,11 +34,21 @@ public class GearTypeService {
     }
 
     public void updateByName(String currentName, String newName) {
-        GearType gearType = gearTypeMapper.findGearTypeByName(currentName);
-        if (gearType == null) {
+        if (isNotValidGearType(gearTypeMapper.findGearTypeByName(currentName))) {
             throw new NoSuchElementException("존재하지 않는 타입 명입니다.");
         }
         gearTypeMapper.updateByName(currentName, newName);
+    }
+
+    public void deleteById(int id) {
+        if (isNotValidGearType(gearTypeMapper.findGearTypeById(id))) {
+            throw new NoSuchElementException("존재하지 않는 타입입니다.");
+        }
+        gearTypeMapper.deleteById(id);
+    }
+
+    private boolean isNotValidGearType(GearType gearType) {
+        return gearType == null;
     }
 
 }

--- a/src/main/java/com/campool/service/GearTypeService.java
+++ b/src/main/java/com/campool/service/GearTypeService.java
@@ -3,6 +3,7 @@ package com.campool.service;
 import com.campool.mapper.GearTypeMapper;
 import com.campool.model.GearType;
 import java.util.List;
+import java.util.NoSuchElementException;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -30,6 +31,14 @@ public class GearTypeService {
 
     public boolean isDuplicateByName(String name) {
         return gearTypeMapper.findGearTypeByName(name) != null;
+    }
+
+    public void updateByName(String currentName, String newName) {
+        GearType gearType = gearTypeMapper.findGearTypeByName(currentName);
+        if (gearType == null) {
+            throw new NoSuchElementException("존재하지 않는 타입 명입니다.");
+        }
+        gearTypeMapper.updateByName(currentName, newName);
     }
 
 }

--- a/src/main/java/com/campool/service/GearTypeService.java
+++ b/src/main/java/com/campool/service/GearTypeService.java
@@ -6,6 +6,7 @@ import java.util.List;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.dao.DuplicateKeyException;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -18,6 +19,17 @@ public class GearTypeService {
     @Cacheable(value = "gearTypes")
     public List<GearType> getGearTypes() {
         return gearTypeMapper.selectGearTypes();
+    }
+
+    public void addGearType(String name) {
+        if (isDuplicateByName(name)) {
+            throw new DuplicateKeyException("이미 등록되어 있는 타입입니다.");
+        }
+        gearTypeMapper.insertGearType(name);
+    }
+
+    public boolean isDuplicateByName(String name) {
+        return gearTypeMapper.findGearTypeByName(name) != null;
     }
 
 }

--- a/src/test/java/com/campool/controller/GearTypeControllerTest.java
+++ b/src/test/java/com/campool/controller/GearTypeControllerTest.java
@@ -1,0 +1,52 @@
+package com.campool.controller;
+
+import com.campool.service.AuthService;
+import com.campool.service.GearTypeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(GearTypeController.class)
+class GearTypeControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockBean
+    GearTypeService gearTypeService;
+
+    @MockBean
+    AuthService authService;
+
+    @DisplayName("올바른 타입 추가 요청 시 200 상태 코드를 반환")
+    @Test
+    void registerGearTypeHasSuccess() throws Exception {
+        this.mockMvc.perform(
+                post("/types")
+                        .param("name", "gearTypeName"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("255자를 초과한 타입 추가 요청 시 400 상태 코드를 응답")
+    @Test
+    void registerGearTypeOver255HasError() throws Exception {
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < 256; i++) {
+            builder.append("a");
+        }
+
+        String gearTypeNameOver255 = builder.toString();
+
+        this.mockMvc.perform(
+                post("/types")
+                        .param("name", gearTypeNameOver255))
+                .andExpect(status().is4xxClientError());
+    }
+
+}

--- a/src/test/java/com/campool/controller/GearTypeControllerTest.java
+++ b/src/test/java/com/campool/controller/GearTypeControllerTest.java
@@ -10,6 +10,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(GearTypeController.class)
@@ -26,7 +27,7 @@ class GearTypeControllerTest {
 
     @DisplayName("올바른 타입 추가 요청 시 200 상태 코드를 반환")
     @Test
-    void registerGearTypeHasSuccess() throws Exception {
+    void registerGearTypeSuccess() throws Exception {
         this.mockMvc.perform(
                 post("/types")
                         .param("name", "gearTypeName"))
@@ -47,6 +48,25 @@ class GearTypeControllerTest {
                 post("/types")
                         .param("name", gearTypeNameOver255))
                 .andExpect(status().is4xxClientError());
+    }
+
+    @DisplayName("현재 타입 명이 없는 변경 요청 시 400 상태 코드를 응답")
+    @Test
+    void updateGearTypeWithoutCurrentNameHasError() throws Exception {
+        this.mockMvc.perform(
+                patch("/types")
+                        .param("newName", "newGearType"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @DisplayName("올바른 타입 변경 요청 시 200 상태 코드를 반환")
+    @Test
+    void updateGearTypeSuccess() throws Exception {
+        this.mockMvc.perform(
+                patch("/types")
+                        .param("currentName", "currentGearType")
+                        .param("newName", "newGearType"))
+                .andExpect(status().isOk());
     }
 
 }

--- a/src/test/java/com/campool/controller/GearTypeControllerTest.java
+++ b/src/test/java/com/campool/controller/GearTypeControllerTest.java
@@ -30,7 +30,7 @@ class GearTypeControllerTest {
     @Test
     void registerGearTypeSuccess() throws Exception {
         this.mockMvc.perform(
-                post("/types")
+                post("/gear-types")
                         .param("name", "gearTypeName"))
                 .andExpect(status().isOk());
     }
@@ -46,7 +46,7 @@ class GearTypeControllerTest {
         String gearTypeNameOver255 = builder.toString();
 
         this.mockMvc.perform(
-                post("/types")
+                post("/gear-types")
                         .param("name", gearTypeNameOver255))
                 .andExpect(status().is4xxClientError());
     }
@@ -55,7 +55,7 @@ class GearTypeControllerTest {
     @Test
     void updateGearTypeWithoutCurrentNameHasError() throws Exception {
         this.mockMvc.perform(
-                patch("/types")
+                patch("/gear-types")
                         .param("newName", "newGearType"))
                 .andExpect(status().is4xxClientError());
     }
@@ -64,7 +64,7 @@ class GearTypeControllerTest {
     @Test
     void updateGearTypeSuccess() throws Exception {
         this.mockMvc.perform(
-                patch("/types")
+                patch("/gear-types")
                         .param("currentName", "currentGearType")
                         .param("newName", "newGearType"))
                 .andExpect(status().isOk());
@@ -73,14 +73,14 @@ class GearTypeControllerTest {
     @DisplayName("순수 정수로 변경 불가능한 ID로 삭제 요청 시 400 상태 코드를 응답")
     @Test
     void deleteGearTypeByStringHasErrors() throws Exception {
-        this.mockMvc.perform(delete("/types/gearTypeId"))
+        this.mockMvc.perform(delete("/gear-types/gearTypeId"))
                 .andExpect(status().is4xxClientError());
     }
 
     @DisplayName("정수로 변환 가능한 ID로 삭제 요청 시 200 상태 코드를 반환")
     @Test
     void deleteGearTypeByNumberSuccess() throws Exception {
-        this.mockMvc.perform(delete("/types/123"))
+        this.mockMvc.perform(delete("/gear-types/123"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/campool/controller/GearTypeControllerTest.java
+++ b/src/test/java/com/campool/controller/GearTypeControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(GearTypeController.class)
@@ -66,6 +67,20 @@ class GearTypeControllerTest {
                 patch("/types")
                         .param("currentName", "currentGearType")
                         .param("newName", "newGearType"))
+                .andExpect(status().isOk());
+    }
+
+    @DisplayName("순수 정수로 변경 불가능한 ID로 삭제 요청 시 400 상태 코드를 응답")
+    @Test
+    void deleteGearTypeByStringHasErrors() throws Exception {
+        this.mockMvc.perform(delete("/types/gearTypeId"))
+                .andExpect(status().is4xxClientError());
+    }
+
+    @DisplayName("정수로 변환 가능한 ID로 삭제 요청 시 200 상태 코드를 반환")
+    @Test
+    void deleteGearTypeByNumberSuccess() throws Exception {
+        this.mockMvc.perform(delete("/types/123"))
                 .andExpect(status().isOk());
     }
 

--- a/src/test/java/com/campool/service/GearTypeServiceTest.java
+++ b/src/test/java/com/campool/service/GearTypeServiceTest.java
@@ -57,4 +57,16 @@ class GearTypeServiceTest {
 
     }
 
+    @DisplayName("존재하지 않는 ID로 삭제 요청 시 예외 발생")
+    @Test
+    void deleteNonExistentIdThrowsException() {
+        int nonExistentId = 123;
+        given(gearTypeMapper.findGearTypeById(nonExistentId)).willReturn(null);
+
+        Exception exception = assertThrows(NoSuchElementException.class,
+                () -> gearTypeService.deleteById(123));
+
+        assertEquals("존재하지 않는 타입입니다.", exception.getMessage());
+    }
+
 }

--- a/src/test/java/com/campool/service/GearTypeServiceTest.java
+++ b/src/test/java/com/campool/service/GearTypeServiceTest.java
@@ -60,7 +60,7 @@ class GearTypeServiceTest {
     @DisplayName("존재하지 않는 ID로 삭제 요청 시 예외 발생")
     @Test
     void deleteNonExistentIdThrowsException() {
-        int nonExistentId = 123;
+        long nonExistentId = 123;
         given(gearTypeMapper.findGearTypeById(nonExistentId)).willReturn(null);
 
         Exception exception = assertThrows(NoSuchElementException.class,

--- a/src/test/java/com/campool/service/GearTypeServiceTest.java
+++ b/src/test/java/com/campool/service/GearTypeServiceTest.java
@@ -1,0 +1,45 @@
+package com.campool.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.campool.mapper.GearTypeMapper;
+import com.campool.model.GearType;
+import com.campool.model.GearTypeRegisterRequest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DuplicateKeyException;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class GearTypeServiceTest {
+
+    @InjectMocks
+    GearTypeService gearTypeService;
+
+    @Mock
+    GearTypeMapper gearTypeMapper;
+
+    GearType gearType;
+
+    @BeforeEach
+    void setUp() {
+        gearType = new GearType(1, "gearType");
+    }
+
+    @Test
+    void addDuplicateGearTypeNameThrowsException() {
+        String duplicateGearTypeName = "gearType";
+        given(gearTypeMapper.findGearTypeByName(gearType.getName())).willReturn(gearType);
+
+        Exception exception = assertThrows(DuplicateKeyException.class,
+                () -> gearTypeService.addGearType(duplicateGearTypeName));
+
+        assertEquals("이미 등록되어 있는 타입입니다.", exception.getMessage());
+    }
+
+}

--- a/src/test/java/com/campool/service/GearTypeServiceTest.java
+++ b/src/test/java/com/campool/service/GearTypeServiceTest.java
@@ -51,7 +51,7 @@ class GearTypeServiceTest {
         given(gearTypeMapper.findGearTypeByName(nonExistentName)).willReturn(null);
 
         Exception exception = assertThrows(NoSuchElementException.class,
-                () -> gearTypeService.update("currentName", "newName"));
+                () -> gearTypeService.updateByName("currentName", "newName"));
 
         assertEquals("존재하지 않는 타입 명입니다.", exception.getMessage());
 

--- a/src/test/java/com/campool/service/GearTypeServiceTest.java
+++ b/src/test/java/com/campool/service/GearTypeServiceTest.java
@@ -4,8 +4,9 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import com.campool.mapper.GearTypeMapper;
 import com.campool.model.GearType;
-import com.campool.model.GearTypeRegisterRequest;
+import java.util.NoSuchElementException;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -31,15 +32,29 @@ class GearTypeServiceTest {
         gearType = new GearType(1, "gearType");
     }
 
+    @DisplayName("중복된 타입의 추가 요청은 중복 예외를 발생")
     @Test
     void addDuplicateGearTypeNameThrowsException() {
-        String duplicateGearTypeName = "gearType";
         given(gearTypeMapper.findGearTypeByName(gearType.getName())).willReturn(gearType);
+        String duplicateGearTypeName = "gearType";
 
         Exception exception = assertThrows(DuplicateKeyException.class,
                 () -> gearTypeService.addGearType(duplicateGearTypeName));
 
         assertEquals("이미 등록되어 있는 타입입니다.", exception.getMessage());
+    }
+
+    @DisplayName("존재하지 않는 현재 타입 명으로 요청 시 예외 발생")
+    @Test
+    void updateNonExistentCurrentNameThrowsException() {
+        String nonExistentName = "currentName";
+        given(gearTypeMapper.findGearTypeByName(nonExistentName)).willReturn(null);
+
+        Exception exception = assertThrows(NoSuchElementException.class,
+                () -> gearTypeService.update("currentName", "newName"));
+
+        assertEquals("존재하지 않는 타입 명입니다.", exception.getMessage());
+
     }
 
 }


### PR DESCRIPTION
## 작업 내용
관리자가 캠핑용품 타입 데이터를 등록, 수정, 삭제할 수 있는 기능을 추가하였습니다.

## 주의 사항
관리자 권한을 가진 경우만 요청 가능

>  참조이슈
> #35 

