### PR TITLE
DB 및 쿼리 리팩토링

### DIFF
--- a/src/main/java/com/campool/mapper/RentalMapper.java
+++ b/src/main/java/com/campool/mapper/RentalMapper.java
@@ -20,7 +20,7 @@ public interface RentalMapper {
 
     List<CampingGear> findGearsByRentalId(long rentalId);
 
-    List<Rental> selectRentalsByLocation(RentalsRequestByLocation rentalsRequestByLocation);
+    List<Rental> selectRentalsByLocation(RentalsRequestByLocation rental, String polygon);
 
     Integer selectCostByIdAndDate(long id, LocalDate startDate, LocalDate endDate);
 

--- a/src/main/java/com/campool/service/RentalService.java
+++ b/src/main/java/com/campool/service/RentalService.java
@@ -18,6 +18,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class RentalService {
 
+    private static final double LONGITUDE_PER_METER = 0.0000113182;
+    private static final double LATITUDE_PER_METER = 0.0000089426;
+
     @NonNull
     private final RentalMapper rentalMapper;
 
@@ -51,8 +54,8 @@ public class RentalService {
     }
 
     private String getPolygonString(double longitude, double latitude, int meters) {
-        double differenceX = 0.0000113182 * meters;
-        double differenceY = 0.0000089426 * meters;
+        double differenceX = LONGITUDE_PER_METER * meters;
+        double differenceY = LATITUDE_PER_METER * meters;
 
         double X1 = longitude - differenceX;
         double X2 = longitude + differenceX;

--- a/src/main/java/com/campool/service/RentalService.java
+++ b/src/main/java/com/campool/service/RentalService.java
@@ -6,6 +6,7 @@ import com.campool.model.Rental;
 import com.campool.model.RentalInfo;
 import com.campool.model.RentalRegisterRequest;
 import com.campool.model.RentalsRequestByLocation;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.NoSuchElementException;
 import lombok.NonNull;
@@ -18,8 +19,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class RentalService {
 
-    private static final double LONGITUDE_PER_METER = 0.0000113182;
-    private static final double LATITUDE_PER_METER = 0.0000089426;
+    private static final BigDecimal LONGITUDE_PER_METER = new BigDecimal("0.0000113182");
+    private static final BigDecimal LATITUDE_PER_METER = new BigDecimal("0.0000089426");
 
     @NonNull
     private final RentalMapper rentalMapper;
@@ -48,19 +49,20 @@ public class RentalService {
         double longitude = rentalsRequestByLocation.getLongitude();
         double latitude = rentalsRequestByLocation.getLatitude();
 
-        String polygon = getPolygonString(longitude, latitude, meters);
+        String polygon = getPolygonString(new BigDecimal(longitude), new BigDecimal(latitude),
+                new BigDecimal(meters));
 
         return rentalMapper.selectRentalsByLocation(rentalsRequestByLocation, polygon);
     }
 
-    private String getPolygonString(double longitude, double latitude, int meters) {
-        double differenceX = LONGITUDE_PER_METER * meters;
-        double differenceY = LATITUDE_PER_METER * meters;
+    private String getPolygonString(BigDecimal longitude, BigDecimal latitude, BigDecimal meters) {
+        BigDecimal differenceX = LONGITUDE_PER_METER.multiply(meters);
+        BigDecimal differenceY = LATITUDE_PER_METER.multiply(meters);
 
-        double X1 = longitude - differenceX;
-        double X2 = longitude + differenceX;
-        double Y1 = latitude - differenceY;
-        double Y2 = latitude + differenceY;
+        BigDecimal X1 = longitude.subtract(differenceX);
+        BigDecimal X2 = longitude.add(differenceX);
+        BigDecimal Y1 = latitude.subtract(differenceY);
+        BigDecimal Y2 = latitude.add(differenceY);
 
         return "POLYGON(("
                 + X1 + " " + Y1 + ","

--- a/src/main/java/com/campool/service/RentalService.java
+++ b/src/main/java/com/campool/service/RentalService.java
@@ -41,7 +41,30 @@ public class RentalService {
     }
 
     public List<Rental> getRentalsByLocation(RentalsRequestByLocation rentalsRequestByLocation) {
-        return rentalMapper.selectRentalsByLocation(rentalsRequestByLocation);
+        int meters = rentalsRequestByLocation.getDistanceInMeters();
+        double longitude = rentalsRequestByLocation.getLongitude();
+        double latitude = rentalsRequestByLocation.getLatitude();
+
+        String polygon = getPolygonString(longitude, latitude, meters);
+
+        return rentalMapper.selectRentalsByLocation(rentalsRequestByLocation, polygon);
+    }
+
+    private String getPolygonString(double longitude, double latitude, int meters) {
+        double differenceX = 0.0000113182 * meters;
+        double differenceY = 0.0000089426 * meters;
+
+        double X1 = longitude - differenceX;
+        double X2 = longitude + differenceX;
+        double Y1 = latitude - differenceY;
+        double Y2 = latitude + differenceY;
+
+        return "POLYGON(("
+                + X1 + " " + Y1 + ","
+                + X2 + " " + Y1 + ","
+                + X2 + " " + Y2 + ","
+                + X1 + " " + Y2 + ","
+                + X1 + " " + Y1 + "))";
     }
 
 }

--- a/src/main/resources/mapper/RentalMapper.xml
+++ b/src/main/resources/mapper/RentalMapper.xml
@@ -47,7 +47,7 @@
           AND r.id = g.rental_id AND g.type=#{typeId}
           </if>
           AND #{distanceInMeters} > ST_DisTance_Sphere(POINT(#{longitude}, #{latitude}), r.location)
-    </select> // 확인
+    </select>
 
     <select id="findRentalInfoById" resultType="com.campool.model.RentalInfo">
         SELECT id AS rentalId,
@@ -68,7 +68,7 @@
         SELECT name, type AS typeId, count
         FROM gear
         WHERE rental_id = #{rentalId}
-    </select> // 풀 테이블 스캔
+    </select>
 
     <select id="selectCostByIdAndDate" resultType="java.lang.Integer">
         SELECT cost FROM rental

--- a/src/main/resources/mapper/RentalMapper.xml
+++ b/src/main/resources/mapper/RentalMapper.xml
@@ -39,14 +39,14 @@
                ST_X(location) AS longitude,
                ST_Y(location) AS latitude
         FROM rental r
-        <if test="typeId != null">
+        <if test="rental.typeId != null">
         , gear g
         </if>
-        WHERE r.status = 'status1'
-          <if test="typeId != null">
-          AND r.id = g.rental_id AND g.type=#{typeId}
+        WHERE  ST_Within(r.location, ST_GeomFromText(#{polygon}))
+          AND r.status = 'status1'
+          <if test="rental.typeId != null">
+          AND r.id = g.rental_id AND g.type=#{rental.typeId}
           </if>
-          AND #{distanceInMeters} > ST_DisTance_Sphere(POINT(#{longitude}, #{latitude}), r.location)
     </select>
 
     <select id="findRentalInfoById" resultType="com.campool.model.RentalInfo">

--- a/src/main/resources/mapper/RentalMapper.xml
+++ b/src/main/resources/mapper/RentalMapper.xml
@@ -47,7 +47,7 @@
           AND r.id = g.rental_id AND g.type=#{typeId}
           </if>
           AND #{distanceInMeters} > ST_DisTance_Sphere(POINT(#{longitude}, #{latitude}), r.location)
-    </select>
+    </select> // 확인
 
     <select id="findRentalInfoById" resultType="com.campool.model.RentalInfo">
         SELECT id AS rentalId,
@@ -68,7 +68,7 @@
         SELECT name, type AS typeId, count
         FROM gear
         WHERE rental_id = #{rentalId}
-    </select>
+    </select> // 풀 테이블 스캔
 
     <select id="selectCostByIdAndDate" resultType="java.lang.Integer">
         SELECT cost FROM rental

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -15,7 +15,7 @@ CREATE TABLE IF NOT EXISTS `admin` (
 );
 
 CREATE TABLE IF NOT EXISTS `rental` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
+    `id` bigint UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     `title` varchar(255) NOT NULL,
     `description` varchar(255) NOT NULL,
     `status` varchar(50) NOT NULL,
@@ -28,7 +28,7 @@ CREATE TABLE IF NOT EXISTS `rental` (
 );
 
 CREATE TABLE IF NOT EXISTS `gear` (
-    `rental_id` bigint,
+    `rental_id` bigint UNSIGNED,
     `name` varchar(255) NOT NULL,
     `type` bigint NOT NULL,
     `count` int default 1,
@@ -36,12 +36,12 @@ CREATE TABLE IF NOT EXISTS `gear` (
 );
 
 CREATE TABLE IF NOT EXISTS `type` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
+    `id` bigint UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     `name` varchar(255) UNIQUE KEY NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS `booking` (
-    `id` bigint PRIMARY KEY AUTO_INCREMENT,
+    `id` bigint UNSIGNED PRIMARY KEY AUTO_INCREMENT,
     `rental_id` bigint NOT NULL,
     `user_id` varchar(12) NOT NULL,
     `status` varchar(50) NOT NULL,

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE IF NOT EXISTS `gear` (
 
 CREATE TABLE IF NOT EXISTS `type` (
     `id` bigint PRIMARY KEY AUTO_INCREMENT,
-    `name` varchar(255) NOT NULL
+    `name` varchar(255) UNIQUE KEY NOT NULL
 );
 
 CREATE TABLE IF NOT EXISTS `booking` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -31,7 +31,8 @@ CREATE TABLE IF NOT EXISTS `gear` (
     `rental_id` bigint,
     `name` varchar(255) NOT NULL,
     `type` bigint NOT NULL,
-    `count` int default 1
+    `count` int default 1,
+    INDEX(rental_id)
 );
 
 CREATE TABLE IF NOT EXISTS `type` (

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -24,7 +24,8 @@ CREATE TABLE IF NOT EXISTS `rental` (
     `end_date` datetime NOT NULL,
     `cost` int default 0,
     `create_time` timestamp,
-    `location` point
+    `location` point NOT NULL SRID 0,
+    SPATIAL INDEX(location)
 );
 
 CREATE TABLE IF NOT EXISTS `gear` (


### PR DESCRIPTION
## 작업 내용
캠핑용품 유형(type) 테이블의 name 컬럼에 유니크 키를 추가하였습니다. 
-> name 컬럼을 조건으로 사용 시 풀 테이블 스캔 방지
캠핑용품(gear) 테이블의 rental_id 컬럼에 normal 인덱스를 추가하였습니다. 
-> rental_id 컬럼을 조건으로 사용 시 풀 테이블 스캔 방지
모든 테이블의 bigint 컬럼에 UNSIGNED 속성 부여
-> bigint의 음수 범위가 양수 범위로 확장되기 때문에 더 많은 데이터를 양수로 사용 가능
위치기반 조회 시 사용되는 point 타입의 컬럼에 spatial 인덱스를 추가하였고 인덱스를 사용할 수 있도록 쿼리를 변경하였습니다.
-> 위치기반 조회 시 풀 테이블 스캔을 방지

>  참조이슈
> #57 