### PR TITLE
대여 등록한 캠핑용품 삭제 기능

### DIFF
--- a/src/main/java/com/campool/controller/RentalController.java
+++ b/src/main/java/com/campool/controller/RentalController.java
@@ -17,6 +17,7 @@ import javax.validation.Valid;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -68,6 +69,12 @@ public class RentalController {
     public void completeRental(@Valid RentalCompleteRequest request, @LoginUserId String userId) {
         BookingInfo bookingInfo = bookingService.getBookingInfoById(request.getBookingId());
         rentalService.completeRental(request.getRentalId(), bookingInfo, userId);
+    }
+
+    @LoginValidation
+    @DeleteMapping("/rentals/{rentalId}")
+    public void deleteRental(@PathVariable long rentalId, @LoginUserId String userId) {
+        rentalService.deleteRental(rentalId, userId);
     }
 
 }

--- a/src/main/java/com/campool/mapper/RentalMapper.java
+++ b/src/main/java/com/campool/mapper/RentalMapper.java
@@ -28,4 +28,6 @@ public interface RentalMapper {
 
     void updateStatusById(long id, RentalStatus status);
 
+    void deleteById(long id);
+
 }

--- a/src/main/java/com/campool/service/RentalService.java
+++ b/src/main/java/com/campool/service/RentalService.java
@@ -101,4 +101,14 @@ public class RentalService {
         return rentalInfo.getStatus() == status && rentalInfo.getUserId().equals(userId);
     }
 
+    @Transactional
+    public void deleteRental(long rentalId, String userId) {
+        RentalInfo rentalInfo = rentalMapper.findRentalInfoById(rentalId);
+        if (rentalInfo.getStatus() != RentalStatus.TRADEABLE
+                || !rentalInfo.getUserId().equals(userId)) {
+            throw new IllegalStateException("본인이 등록하고 거래 가능 상태일 때만 삭제할 수 있습니다.");
+        }
+        rentalMapper.deleteById(rentalId);
+    }
+
 }

--- a/src/main/resources/mapper/RentalMapper.xml
+++ b/src/main/resources/mapper/RentalMapper.xml
@@ -80,4 +80,8 @@
     <update id="updateStatusById">
         UPDATE RENTAL SET status = #{status} WHERE id = #{id}
     </update>
+
+    <delete id="deleteById">
+        DELETE r, g FROM RENTAL r JOIN GEAR g ON g.rental_id = r.id WHERE id = #{id};
+    </delete>
 </mapper>


### PR DESCRIPTION
## 작업 내용
대여 등록한 캠핑용품 중 아직 예약이 없고 본인이 등록한 용품을 삭제하는 기능을 추가하였습니다.

## 주의 사항
예약하지 않은 상태와 본인이 등록한 용품이어야 합니다.

>  참조이슈
> #69 
