### PR TITLE
Redis Session 병목 제거 및 최적화를 위한 Config 수정

### DIFF
--- a/src/main/java/com/campool/configuration/SessionConfiguration.java
+++ b/src/main/java/com/campool/configuration/SessionConfiguration.java
@@ -1,14 +1,23 @@
 package com.campool.configuration;
 
+import java.time.Duration;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.session.config.annotation.web.http.EnableSpringHttpSession;
+import org.springframework.session.data.redis.RedisSessionRepository;
 
+@EnableSpringHttpSession
 @Configuration
 public class SessionConfiguration {
+
+    public static final long MAX_INACTIVE_INTERVAL = 300;
 
     @Value("${campool.redis.session.host}")
     private String sessionHost;
@@ -22,6 +31,25 @@ public class SessionConfiguration {
         redisStandaloneConfiguration.setHostName(sessionHost);
         redisStandaloneConfiguration.setPort(sessionPort);
         return new LettuceConnectionFactory(redisStandaloneConfiguration);
+    }
+
+    @Bean
+    public RedisOperations<String, Object> sessionRedisOperations(
+            RedisConnectionFactory redisConnectionFactory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setHashKeySerializer(new StringRedisSerializer());
+        return template;
+    }
+
+    @Bean
+    public RedisSessionRepository sessionRepository(
+            RedisOperations<String, Object> sessionRedisOperations) {
+        RedisSessionRepository redisSessionRepository = new RedisSessionRepository(
+                sessionRedisOperations);
+        redisSessionRepository.setDefaultMaxInactiveInterval(Duration.ofSeconds(MAX_INACTIVE_INTERVAL));
+        return redisSessionRepository;
     }
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
+spring.session.redis.configure-action=none
 spring.cache.type=redis
 
 # Redis Session


### PR DESCRIPTION
## 작업 배경
1. `RedisHttpSessionConfiguration`에 정의되어 있는 `RedisIndexedSessionRepository`는 세션 만료와 관련된 정책을 따로 사용하기 때문에 기본 세션 정보 이외의 만료 정보가 같이 저장됩니다. 하지만 이 만료 정보 갱신을 위해 수행되는 Redis Operation이 병목을 유발하기 때문에 다른 Repository를 사용하도록 변경할 필요가 있었습니다.

2. `RedisHttpSessionConfiguration`에는 **Redis Keyspace Notification**(Redis에 저장된 Session에서 발생하는 Event를 구독하는 기능)을 활성화하도록 되어 있는데 이 기능은  Campool 서버에서는 필요없고 오버헤드이기 때문에 제거할 필요가 있었습니다.

## 작업 내용
- `RedisIndexedSessionRepository`가 포함된 `Redis Session Config`를 사용하지 않고 `Spring Session Config`를 사용하도록 수정
- Session Event를 사용하지 않기 때문에 Redis Keyspace Notification 끄는 옵션 추가

## 주의 사항
기존에 같이 저장되는 만료 키를 사용하지 않으므로 세션만 저장되도록 변경됩니다.

> 참조이슈
> #76 
> [관련 글](https://liasn.tistory.com/8)
